### PR TITLE
Update examples to render appropriately in mm

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -1,5 +1,2 @@
-export background_color=FF000000
-export dial_color=FFFFFF00
-export show_outline=false
 export from_stdin=true
 ./fake_rpm.py | ./wayland_runner.py examples/tach.py

--- a/examples/art.py
+++ b/examples/art.py
@@ -9,23 +9,23 @@ if __name__ == 'init':
     params.define("right_hip_angle", Angle(default=1.46))
     params.define("left_knee_angle", Angle(default=1.55))
     params.define("right_knee_angle", Angle(default=1.55))
-    params.define("height", Infinite(200))
-    params.define("arm_length", Infinite(50))
-    params.define("thigh_length", Infinite(107.94))
-    params.define("calf_length", Infinite(120.33))
+    params.define("height", Infinite(80))
+    params.define("arm_length", Infinite(25))
+    params.define("thigh_length", Infinite(28))
+    params.define("calf_length", Infinite(46))
     params.setResolution(640, 800)
 else:
-    head_center = Point(320.18, 119.499)
+    head_center = Point(window.center.x, 25)
     pelvis_center = head_center + Point(0, params["height"])
-    shoulder_center = head_center + Point(0, 75)
-    left_shoulder = shoulder_center + Point(-80, 10)
-    right_shoulder = shoulder_center + Point(80, 10)
+    shoulder_center = head_center + Point(0, 35)
+    left_shoulder = shoulder_center + Point(-20, 5)
+    right_shoulder = shoulder_center + Point(20, 5)
     left_elbo = left_shoulder + Point.from_polar(params["arm_length"], params["left_arm_angle"])
     right_elbo = right_shoulder + Point.from_polar(params["arm_length"], params["right_arm_angle"])
     left_wrist = left_elbo + Point.from_polar(params["arm_length"] * 1.2, params["left_elbo_angle"])
     right_wrist = right_elbo + Point.from_polar(params["arm_length"] * 1.2, params["right_elbo_angle"])
-    left_hip = pelvis_center + Point(-30, 0)
-    right_hip = pelvis_center + Point(30, 0)
+    left_hip = pelvis_center + Point(-15, 0)
+    right_hip = pelvis_center + Point(15, 0)
     left_knee = left_hip + Point.from_polar(params["thigh_length"], params["left_hip_angle"])
     right_knee = right_hip + Point.from_polar(params["thigh_length"], params["right_hip_angle"])
     left_ankle = left_knee + Point.from_polar(params["calf_length"], params["left_knee_angle"])
@@ -46,7 +46,7 @@ else:
     cr.stroke()
 
     # head
-    helpers.elipse(head_center, 48, 66)
+    helpers.elipse(head_center, 12, 15)
     fill_stroke(white)
 
     # shoulders
@@ -55,7 +55,7 @@ else:
     helpers.line_to(left_elbo)
     helpers.line_to(left_wrist)
     cr.stroke()
-    helpers.circle(left_wrist, 20)
+    helpers.circle(left_wrist, 5)
     fill_stroke(white)
 
     helpers.move_to(shoulder_center)
@@ -63,7 +63,7 @@ else:
     helpers.line_to(right_elbo)
     helpers.line_to(right_wrist)
     cr.stroke()
-    helpers.circle(right_wrist, 20)
+    helpers.circle(right_wrist, 5)
     fill_stroke(white)
 
     #torso
@@ -76,13 +76,13 @@ else:
     helpers.line_to(left_knee)
     helpers.line_to(left_ankle)
     cr.stroke()
-    helpers.circle(left_ankle, 25)
+    helpers.circle(left_ankle, 7)
     fill_stroke(white)
 
     helpers.move_to(right_hip)
     helpers.line_to(right_knee)
     helpers.line_to(right_ankle)
     cr.stroke()
-    helpers.circle(right_ankle, 25)
+    helpers.circle(right_ankle, 7)
     fill_stroke(white)
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -3,7 +3,8 @@ if __name__ == "init":
     params.define("n_waves", Numeric(2, 100, 1, 12))
     params.define("speed", Numeric(0, 2, 0.125, 0.3))
     params.define("color", Color(1, 0, 0, 0.75))
-    params.setResolution(320, 240)
+    params.define("radius", Infinite(5.0))
+    params.setResolution(640, 480)
 else:
     import time
     
@@ -18,7 +19,7 @@ else:
             for i in range(stars):
                 with helpers.save():
                     cr.rotate(i * angle + phase)
-                    cr.arc(phase * radius, 0, 10, 0, 2 * math.pi)
+                    cr.arc(phase * radius, 0, params["radius"], 0, 2 * math.pi)
                     cr.fill()
 
         

--- a/examples/tach.py
+++ b/examples/tach.py
@@ -9,7 +9,7 @@ if __name__ == "init":
     params.define("hub_radius", Numeric(2, 100, 1, 20))
     params.define("number_radius", Numeric(0, 1, 1/256.0, 0.8))
     params.define("tick_radius", Numeric(0, 1, 1/256.0, 0.475))
-    params.define("needle_radius", Numeric(0, 1, 1/256.0, 0.80))
+    params.define("needle_radius", Numeric(0, 1, 1/256.0, 0.6))
     params.define("tick_length", Numeric(0, 1, 1/256.0, 0.150))
     params.define("rpm", Numeric(0, 6500, 1, 1000))
     params.define("show_outline", Toggle(False))
@@ -17,10 +17,10 @@ if __name__ == "init":
     params.define("background_color", Color(0, 0, 0))
     params.define("dial_color", Color(0xED/255, 0xD4/255, 0))
     params.define("needle_color", Color(1, 0, 0))
-    params.define("text_size", Numeric(0, 96, 1, 52))
+    params.define("text_size", Numeric(0, 52, 1, 11))
     params.define("label", Text("RPM x 100"))
-    params.define("label_offset", Infinite(-67))
-    params.setResolution(1280, 720)
+    params.define("label_offset", Infinite(-20))
+    params.setResolution(1600, 900)
 else:
     arc_length = params["arc_length"]
     arc_remainder = 2 * math.pi - arc_length
@@ -44,7 +44,7 @@ else:
         radius = min(bounds.width, bounds.height) * 0.5
         hub_radius = max(5, radius / params["hub_radius"])
 
-        cr.set_line_width(5)
+        cr.set_line_width(4.0)
         cr.set_line_cap(cairo.LineCap.ROUND)
         cr.set_font_size(params["text_size"])
         for tick in range(int(min_rpm), int(max_rpm), int(ticks)):
@@ -63,7 +63,7 @@ else:
 
         cr.stroke()
 
-        cr.set_font_size(36)
+        cr.set_font_size(5)
         helpers.move_to(bounds.center + Point(0, params["label_offset"]))
         helpers.center_text(params["label"])
 


### PR DESCRIPTION
Previous change to use set default scaling to mm, instead of device units broke the examples.