### PR TITLE
Add pango support

### DIFF
--- a/cairo_sandbox.py
+++ b/cairo_sandbox.py
@@ -28,10 +28,15 @@ from __future__ import print_function
 
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
 gi.require_foreign("cairo")
 from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Pango
+
+gi.require_version("PangoCairo", "1.0");
+from gi.repository import PangoCairo
 
 from controller import DragController
 from helpers import Point, Rect, Save, Box
@@ -135,7 +140,7 @@ class GUI(object):
         self.render.show_all()
         self.parameters.show_all()
 
-    def reload(self):
+    def reload(self, *unused):
         print("reloading: " + self.path)
         self.param_group = params.ParameterGroup()        
         self.script.reload(self.param_group)

--- a/examples/parameters.py
+++ b/examples/parameters.py
@@ -19,23 +19,21 @@ if __name__ == "init":
     # More complex case, a mapping of keys to values"
     params.define(
         "antialias",
-        Choice(
-            {"Default": cairo.Antialias.DEFAULT,
-             "None": cairo.Antialias.NONE,
-             "Gray": cairo.Antialias.GRAY,
-             "Subpixel": cairo.Antialias.SUBPIXEL,
-             "Fast": cairo.Antialias.FAST,
-             "Good": cairo.Antialias.GOOD,
-             "Best": cairo.Antialias.BEST
-            },
-            "Default"))
+        Choice({
+            "Default": cairo.Antialias.DEFAULT,
+            "None": cairo.Antialias.NONE,
+            "Gray": cairo.Antialias.GRAY,
+            "Subpixel": cairo.Antialias.SUBPIXEL,
+            "Fast": cairo.Antialias.FAST,
+            "Good": cairo.Antialias.GOOD,
+            "Best": cairo.Antialias.BEST
+        }, "Default"))
 
     params.define("image",
                   Image(cairo.SolidPattern(0, 0, 0)))
     params.setResolution(800, 600)
 else:
     cr.set_antialias(params["antialias"])
-    cr.select_font_face(params["font"])
     cr.set_font_size(24)
     (x,y) = window.center
 
@@ -81,7 +79,7 @@ else:
             cr.translate(x, y)
             cr.rotate(params["angle"])
             cr.move_to(0, 0)
-            helpers.center_text(params["text"])
+            helpers.center_text(params["text"], params["font"])
 
         cr.move_to(window.center.x, 100)
-        helpers.center_text(params["multiline"])
+        helpers.center_text(params["multiline"], params["font"])

--- a/helpers.py
+++ b/helpers.py
@@ -70,7 +70,7 @@ class Helper(object):
 
     def polygon(self, *points, close=True):
         self.move_to(points[0])
-        for point in points:
+        for point in points[1:]:
             self.line_to(point)
         if close:
             self.cr.close()

--- a/helpers.py
+++ b/helpers.py
@@ -18,6 +18,12 @@
 
 
 import cairo
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+gi.require_foreign("cairo")
+from gi.repository import Pango
+from gi.repository import PangoCairo
 import cmath
 import math
 import traceback
@@ -29,6 +35,7 @@ class Helper(object):
 
     def __init__(self, cr):
         self.cr = cr
+        self.pr = PangoCairo.create_context(cr)
 
     def circle(self, center, radius):
         self.cr.arc(center.x, center.y, radius, 0, 2 * math.pi)
@@ -39,13 +46,19 @@ class Helper(object):
             self.cr.scale(1.0, height / width)
             self.circle(Point(0, 0), width)
 
-    def center_text(self, text):
+    def show_text(self, text, font):
+        layout = PangoCairo.create_layout(self.cr)
+        layout.set_font_description(font)
+        layout.set_text(text, -1)
+        PangoCairo.show_layout(self.cr, layout)
+
+    def center_text(self, text, font):
         _, _, tw, th, _, _ = self.cr.text_extents(text)
         x, y = self.cr.get_current_point()
         with self.save():
             self.cr.translate(x - tw * 0.5, y + th * 0.5)
             self.cr.move_to(0, 0)
-            self.cr.show_text(text)
+            self.show_text(text, font)
 
     def center_rect(self, center, w, h):
         self.cr.rectangle(center.x - 0.5 * w, center.y - 0.5 * h, w, h)
@@ -230,3 +243,4 @@ class Box(object):
 
     def __exit__(self, unused1, unused2, unused3):
         self.cr.restore()
+ 

--- a/params/gtk.py
+++ b/params/gtk.py
@@ -24,10 +24,12 @@ import time
 import cairo
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
 gi.require_foreign("cairo")
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Pango
 
 from controller import ValueController
 from helpers import Helper, Rect, Point
@@ -240,16 +242,10 @@ class FontParameter(Parameter):
 
     """An easy way to chose a specific font."""
 
-    # TBD: When we support Pango for text, revisit this control.
-
-    def __init__(self, default="monospace", use_pango=False):
+    def __init__(self, default="monospace"):
         self.require(default, (str, type(None)))
-        self.require(use_pango, bool)
-        if (use_pango):
-            raise NotImplementedError()
-        self.use_pango = use_pango
         self.default = default
-        self.value = default
+        self.value = Pango.FontDescription(default)
         self.widget = None
 
     def makeWidget(self):
@@ -264,7 +260,8 @@ class FontParameter(Parameter):
         return self.widget
 
     def update(self, *unused):
-        self.value = self.widget.get_font().split()[0]
+        self.value = self.widget.get_font_desc()
+        print(self.value)
 
     def getValue(self):
         return self.value


### PR DESCRIPTION
This has been a long time coming, because honestly I wish cairo just wrapped the Pango API, and that the "toy" text rendering API was complete. I don't like having to use two separate libraries for graphics and text. But I finally bit the bullet and just did it.