### PR TITLE
Guides and Grids

### DIFF
--- a/examples/grid.py
+++ b/examples/grid.py
@@ -1,0 +1,29 @@
+"""Demonstrates the use of the `grid` method on Rect objects.
+"""
+
+if __name__ == "init":
+    params.define("rows",        Numeric(1, 100, 1, 5))
+    params.define("cols",        Numeric(1, 100, 1, 5))
+    params.define("row",         Numeric(1, 100, 1, 1))
+    params.define("col",         Numeric(1, 100, 1, 1))
+    params.define("font",        Font("monospace 3"))
+    params.define("col_first",   Toggle(True))
+    params.define("show_guides", Toggle(False))
+else:
+    g = window.grid(int(cols), int(rows))
+    cr.set_source_rgb(1, 1, 1)
+    cr.paint()
+
+    cr.set_source_rgb(0, 0, 0)
+    for (i, cell) in enumerate(g.cells(col_first)):
+        with helpers.box(cell):
+            cr.move_to(0, 0)
+            helpers.center_text(str(i), font)
+
+    with helpers.box(g.cell(int(col), int(row))) as cell:
+        cr.set_source_rgb(1, 0, 0)
+        helpers.circle(Point(0, 0), cell.radius() - 5)
+        cr.stroke()
+
+    if show_guides:
+        g.debug(helpers)

--- a/examples/guides.py
+++ b/examples/guides.py
@@ -1,0 +1,50 @@
+"""Demonstrates the use of the `guides` method on Rect objects.
+
+Creates a simple 3-pane layout, common among web pages. In some ways this is a
+bad example, since you should probably use split_left in order to specify an
+absolute width for the side bar, rather than a percentage width.
+
+But let's not worry about that for now.
+"""
+
+if __name__ == "init":
+    params.define("side_bar",    Numeric(0, 1, 1/128, 1/3))
+    params.define("status_bar",  Numeric(0, 1, 1/128, 15/16))
+    params.define("background",  Color(1, 1, 1))
+    params.define("text",        Color())
+    params.define("font",        Font("monospace 3"))
+    params.define("show_guides", Toggle(False))
+else:
+    g = window.guides((side_bar,), (status_bar,))
+
+    helpers.rect(window)
+    cr.set_source(background)
+    cr.fill()
+
+    cr.set_source(text)
+    with helpers.box(g.cell(0, 0)):
+        cr.move_to(0, 0)
+        helpers.center_text("Sidebar", font)
+
+    with helpers.box(g.cell(1, 0)) as content:
+        helpers.circle(Point(0, 0), content.radius() - 5)
+        with helpers.save():
+            cr.set_source_rgba(1, 0, 0, 0.5)
+            cr.fill()
+        cr.move_to(0, 0)
+        helpers.center_text("Content Region", font)
+
+    with helpers.box(g.row(1)) as status:
+        cr.move_to(0, 0)
+        cr.set_source(text)
+        helpers.center_text("Status Bar", font)
+
+    if show_guides:
+        g.debug(helpers)
+    else:
+        cr.set_line_width(2)
+        cr.set_source_rgba(0, 0, 0, 0.5)
+        helpers.hline(g.horizontal[1], window)
+        helpers.move_to(g.intersection(1, 0))
+        helpers.line_to(g.intersection(1, 1))
+        cr.stroke()

--- a/helpers.py
+++ b/helpers.py
@@ -281,6 +281,15 @@ class Rect(object):
     def guides(self, vertical, horizontal):
         return Guides(self, vertical, horizontal)
 
+    def grid(self, cols, rows):
+        x_step = 1 / cols
+        y_step = 1 / rows
+        return Guides(
+            self,
+            (i / cols for i in range(1, cols + 1)),
+            (i / rows for i in range(1, rows + 1))
+        )
+
 
 class Save(object):
 
@@ -377,6 +386,8 @@ class Guides:
     If you want to refer to and entire row or column, use the `row()` or
     `col()` methods.
 
+    You can also iterate over all cells in row-first or col-first order.
+
     Note: guide positions are "absolute" positions from the top or left
     edge. In order for indexing to work correctly, horizontal and
     vertical guide positions are sorted in ascending order. To avoid
@@ -407,6 +418,16 @@ class Guides:
         size = br - tl
         return Rect.from_top_left(tl, size.x, size.y)
 
+    def cells(self, col_first=True):
+        if col_first:
+            for i in range(len(self.horizontal) - 2):
+                for j in range(len(self.vertical) - 2):
+                    yield self.cell(j, i)
+        else:
+            for i in range(len(self.vertical) - 2):
+                for j in range(len(self.horizontal) - 2):
+                    yield self.cell(i, j)
+
     def column(self, h):
         tl = self.intersection(h, 0)
         tr = self.intersection(h + 1, 0)
@@ -427,9 +448,9 @@ class Guides:
         """
         if show_outline:
             helpers.rect(self.rect)
-        for h in self.horizontal:
+        for h in self.horizontal[1:-1]:
             helpers.hline(h, self.rect)
-        for v in self.vertical:
+        for v in self.vertical[1:-1]:
             helpers.vline(v, self.rect)
 
     # TBD: add show_indices option


### PR DESCRIPTION
Adds an easy way to subdivide rectangles.

Guides: general method using arbitrary horizontal and vertical lines.
Grid: special case for uniform sizing.

See the examples for more.